### PR TITLE
point to new libneurosim repository

### DIFF
--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /home/docker/packages
 RUN wget https://github.com/nest/nest-simulator/releases/download/v$NEST_VER/$NEST.tar.gz
 RUN wget http://www.neuron.yale.edu/ftp/neuron/versions/v$NRN_VER/$NRN.tar.gz
 RUN tar xzf $NEST.tar.gz; tar xzf $NRN.tar.gz; rm $NEST.tar.gz $NRN.tar.gz
-RUN svn co --username Anonymous --password Anonymous --non-interactive http://svn.incf.org/svn/libneurosim/trunk libneurosim
+RUN git clone --depth 1 https://github.com/INCF/libneurosim.git
 RUN cd libneurosim; ./autogen.sh
 
 COPY nest.patch $HOME/nest.patch


### PR DESCRIPTION
I tried to build the simulate docker image today and https://www.incf.org/svn/libneurosim/trunk was not found.  It looks like that project is now hosted at https://github.com/INCF/libneurosim.git

This change allows the image to be built, but I don't have the resources to check whether that is the correct repository or whether the resulting docker image is using the library properly.

I also noticed the Dockerfiles that are deployed to DockerHub appear to be out of date with the GitHub versions, which is why I was building them in the first place.

Thank you for providing these scripts.  I hope this pull request is helpful.