### PR TITLE
Updates for py3 for pynn094

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+/base/generate.sh
+/simulationx/runLocal.sh
+/simulationx/regenerateAll.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Available images:
 
-- simulation: NEST 2.14, NEURON 7.5, PyNN 0.9 and the scientific Python stack
+- simulation: NEST, NEURON, Brian, PyNN (for specific versions see [Dockerfile](simulation/Dockerfile)) and the scientific Python stack
   - For **Python 3** use the [master branch](https://github.com/NeuralEnsemble/neuralensemble-docker/tree/master/simulation)
   - For **Python 2** use the [python2 branch](https://github.com/NeuralEnsemble/neuralensemble-docker/tree/python2/simulation)
 - simulationx: like "simulation", but with support for X11 forwarding over SSH

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -10,7 +10,7 @@ ENV LANG=C.UTF-8
 
 RUN apt-get update; apt-get install -y automake libtool build-essential openmpi-bin libopenmpi-dev git vim  \
                        wget python3 libpython3-dev libncurses5-dev libreadline-dev libgsl0-dev cython3 \
-                       python3-pip python3-numpy python3-scipy python3-matplotlib python3-jinja2 python3-mock \
+                       python3-numpy python3-scipy python3-matplotlib python3-jinja2 python3-mock \
                        ipython3 python3-httplib2 python3-docutils python3-yaml \
                        subversion python3-venv python3-mpi4py python3-tables python3-h5py cmake zlib1g-dev
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@
 # A base Docker image for Python-based computational neuroscience and neurophysiology
 #
 
-FROM neurodebian:jessie
+FROM neurodebian:xenial
 MAINTAINER andrew.davison@unic.cnrs-gif.fr
 
 ENV DEBIAN_FRONTEND noninteractive
@@ -12,7 +12,7 @@ RUN apt-get update; apt-get install -y automake libtool build-essential openmpi-
                        wget python3 libpython3-dev libncurses5-dev libreadline-dev libgsl0-dev cython3 \
                        python3-pip python3-numpy python3-scipy python3-matplotlib python3-jinja2 python3-mock \
                        ipython3 python3-httplib2 python3-docutils python3-yaml \
-                       subversion python3-venv python3-mpi4py python3-tables python3-h5py cmake
+                       subversion python3-venv python3-mpi4py python3-tables python3-h5py cmake zlib1g-dev
 
 RUN useradd -ms /bin/bash docker
 USER docker
@@ -26,5 +26,5 @@ ENV VENV=$HOME/env/neurosci
 RUN python3 -m venv $VENV && python3 -m venv --system-site-packages $VENV
 
 RUN $VENV/bin/pip3 install --upgrade pip
-RUN $VENV/bin/pip3 install parameters quantities neo "django<1.9" django-tagging future hgapi gitpython sumatra nixio
+RUN $VENV/bin/pip3 install parameters quantities neo==0.6.1 "django<1.9" django-tagging future hgapi gitpython sumatra nixio
 RUN $VENV/bin/pip3 install --upgrade nose ipython

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,5 +26,5 @@ ENV VENV=$HOME/env/neurosci
 RUN python3 -m venv $VENV && python3 -m venv --system-site-packages $VENV
 
 RUN $VENV/bin/pip3 install --upgrade pip
-RUN $VENV/bin/pip3 install parameters quantities neo==0.6.1 "django<1.9" django-tagging future hgapi gitpython sumatra nixio
+RUN $VENV/bin/pip3 install parameters quantities neo==0.7.1 "django<1.9" django-tagging future hgapi gitpython sumatra nixio
 RUN $VENV/bin/pip3 install --upgrade nose ipython

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -26,5 +26,6 @@ ENV VENV=$HOME/env/neurosci
 RUN python3 -m venv $VENV && python3 -m venv --system-site-packages $VENV
 
 RUN $VENV/bin/pip3 install --upgrade pip
-RUN $VENV/bin/pip3 install parameters quantities neo==0.7.1 "django<1.9" django-tagging future hgapi gitpython sumatra nixio
+# Using specific version of neo, due to this issue: https://github.com/NeuralEnsemble/neuralensemble-docker/issues/9#issuecomment-483764236
+RUN $VENV/bin/pip3 install parameters quantities neo==0.7.2 "django<1.9" django-tagging future hgapi gitpython sumatra nixio
 RUN $VENV/bin/pip3 install --upgrade nose ipython

--- a/base/regenerate.sh
+++ b/base/regenerate.sh
@@ -1,0 +1,1 @@
+docker build -t neuralensemble/base --no-cache .

--- a/base/regenerate.sh
+++ b/base/regenerate.sh
@@ -1,1 +1,1 @@
-docker build -t neuralensemble/base_newpy3 --no-cache .
+docker build -t neuralensemble/base --no-cache .

--- a/base/regenerate.sh
+++ b/base/regenerate.sh
@@ -1,1 +1,1 @@
-docker build -t neuralensemble/base --no-cache .
+docker build -t neuralensemble/base_newpy3 --no-cache .

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -61,18 +61,22 @@ ENV NEST_INSTALL_DIR=$HOME/env/neurosci
 
 # Install NetPyNE
 
+RUN apt-get remove -y python3-cycler python3-matplotlib
+RUN $VENV/bin/pip install  matplotlib==2.2.4
+RUN $VENV/bin/pip install netpyne==0.9.5 
+
 ##RUN git clone https://github.com/Neurosim-lab/netpyne.git  && \
 ##    cd netpyne && \
 ##    git checkout neuroml_updates && \
-##    $HOME/env/neurosci/bin/python setup.py install && \
+##    python setup.py install && \
 ##    cd -
 
 
 # Install GENESIS
 
-###RUN apt-get install -y bison flex unzip
-###RUN $VENV/bin/omv install genesis
-###ENV PATH=$PATH:$HOME/genesis/genesis2.4gamma-master/src
+RUN apt-get install -y bison flex unzip
+RUN $VENV/bin/omv install genesis
+ENV PATH=$PATH:$HOME/genesis/genesis2.4gamma-master/src
 
 
 # Install OSB_API

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -25,7 +25,6 @@ RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 RUN $VENV/bin/pip install git+https://github.com/NeuralEnsemble/libNeuroML.git@development
 RUN $VENV/bin/pip install git+https://github.com/NeuroML/pyNeuroML
 
-RUN $VENV/bin/pip install pandas==0.23.4 
 ###RUN $VENV/bin/pip install matplotlib==2.2.4
 
 # Install OMV
@@ -61,8 +60,8 @@ ENV NEST_INSTALL_DIR=$HOME/env/neurosci
 
 # Install NetPyNE
 
-RUN apt-get remove -y python3-cycler python3-matplotlib
-RUN $VENV/bin/pip install  matplotlib==2.2.4
+RUN apt-get remove -y python3-cycler python3-matplotlib python3-dateutil
+RUN $VENV/bin/pip install matplotlib==2.2.4 pandas==0.23.4 python-dateutil==2.5.0
 RUN $VENV/bin/pip install netpyne==0.9.5 
 
 ##RUN git clone https://github.com/Neurosim-lab/netpyne.git  && \
@@ -93,7 +92,11 @@ RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 
 # Install Moose
 
-###RUN omv install Moose
+# Compile Moose with /usr/bin/python3, but install with venv version...
+# Caused by (not insurmountable) issue finding python headers in venv
+RUN git clone https://github.com/pgleeson/moose-core.git && cd moose-core && \
+    mkdir build_ && cd build_ && cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 .. && \
+    make -j4 && make install && cd python && $VENV/bin/python setup.py install
 
 
 # Update PyNN

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -1,0 +1,130 @@
+#
+# A Docker image for running neuronal models from Open Source Brain
+#
+# This image extends the basic "simulationx" image by adding support
+# for libraries required for OSB models
+#
+
+# Use tagged version of neuralensemble/simulationx, e.g. Python 2, PyNN 0.9.1
+#FROM neuralensemble/simulationx:py2_pynn091
+# Temp for testing
+FROM neuralensemble/simulationx_newpy3
+MAINTAINER p.gleeson@gmail.com
+
+USER root
+
+RUN apt-get update 
+RUN apt-get install -y default-jdk python-tk python-lxml octave maven
+RUN apt-get install -y htop libxml2-dev libxslt-dev zlib1g-dev
+
+RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
+
+
+# Install NeuroML Python libraries
+
+RUN pip install git+https://github.com/NeuralEnsemble/libNeuroML.git@development
+RUN pip install git+https://github.com/NeuroML/pyNeuroML
+
+
+# Install OMV
+
+RUN git clone https://github.com/OpenSourceBrain/osb-model-validation.git
+RUN cd osb-model-validation && python setup.py install && cd -
+RUN sed -i -e s/'\/usr\/bin\/python'/'\/home\/docker\/env\/neurosci\/bin\/python'/g /usr/local/bin/omv
+
+
+# Install jNeuroML, PyLEMS & NeuroML2
+
+RUN omv install jNeuroML
+ENV JNML_HOME=$HOME/jnml/jNeuroMLJar
+
+RUN omv install jLEMS
+ENV LEMS_HOME=$HOME/jLEMS
+
+RUN omv install PyLEMS_NeuroML2
+
+ENV PATH=$PATH:$JNML_HOME:$LEMS_HOME
+
+
+# Set up NEURON (should be updated in neuralensemble/simulationx:py2...)
+
+ENV PATH=$PATH:$HOME/env/neurosci/x86_64/bin
+ENV NEURON_HOME=$HOME/env/neurosci/x86_64
+
+
+# Set up NEST
+
+ENV NEST_INSTALL_DIR=$HOME/env/neurosci
+
+
+# Install NetPyNE
+
+RUN $HOME/env/neurosci/bin/pip install pandas==0.23.4 matplotlib==2.2.4
+RUN git clone https://github.com/Neurosim-lab/netpyne.git  && \
+    cd netpyne && \
+    git checkout neuroml_updates && \
+    $HOME/env/neurosci/bin/python setup.py install && \
+    cd -
+
+
+# Install GENESIS
+
+RUN apt-get install -y bison flex unzip
+RUN omv install genesis
+ENV PATH=$PATH:$HOME/genesis/genesis2.4gamma-master/src
+
+
+# Install OSB_API
+
+RUN git clone https://github.com/OpenSourceBrain/OSB_API.git
+RUN cd OSB_API/python && python setup.py install && cd -
+
+
+# Install neuroConstruct
+
+RUN git clone git://github.com/NeuralEnsemble/neuroConstruct.git
+RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
+
+
+# Install Moose
+
+RUN omv install Moose
+
+
+# Update PyNN
+
+USER docker
+RUN $HOME/env/neurosci/bin/pip uninstall pynn -y
+
+USER root
+RUN git clone https://github.com/NeuralEnsemble/PyNN.git  && \
+    cd  PyNN && \
+    git checkout neuroml && \  
+    $HOME/env/neurosci/bin/python  setup.py install && \
+    cd -   # neuroml branch has the latest NML2 import/export code!
+RUN which python
+
+# Update Brian
+
+RUN git clone https://github.com/brian-team/brian.git
+RUN cd brian && $HOME/env/neurosci/bin/python setup.py install && cd -
+
+
+# Install Brian2
+
+RUN $HOME/env/neurosci/bin/pip install Brian2
+
+
+# Get some latest Python packages
+
+RUN $HOME/env/neurosci/bin/pip install lazyarray --upgrade
+
+
+# Some aliases
+
+RUN echo '\n\nalias cd..="cd .."\nalias h=history\nalias ll="ls -alt"' >> ~/.bashrc
+
+RUN echo "Built the main OSB Docker image!"
+
+
+

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -6,9 +6,9 @@
 #
 
 # Use tagged version of neuralensemble/simulationx, e.g. Python 2, PyNN 0.9.1
-#FROM neuralensemble/simulationx:py2_pynn091
+#FROM neuralensemble/simulationx:py2_pynn094
 # Temp for testing
-FROM neuralensemble/simulationx_newpy3
+FROM neuralensemble/simulationx
 MAINTAINER p.gleeson@gmail.com
 
 USER root

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -23,6 +23,7 @@ RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 # Install NeuroML Python libraries
 
 RUN $VENV/bin/pip install git+https://github.com/NeuralEnsemble/libNeuroML.git@development
+RUN $VENV/bin/pip install git+https://github.com/NeuroML/NeuroMLlite
 RUN $VENV/bin/pip install git+https://github.com/NeuroML/pyNeuroML
 
 ###RUN $VENV/bin/pip install matplotlib==2.2.4

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -22,26 +22,28 @@ RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 
 # Install NeuroML Python libraries
 
-RUN pip install git+https://github.com/NeuralEnsemble/libNeuroML.git@development
-RUN pip install git+https://github.com/NeuroML/pyNeuroML
+RUN $VENV/bin/pip install git+https://github.com/NeuralEnsemble/libNeuroML.git@development
+RUN $VENV/bin/pip install git+https://github.com/NeuroML/pyNeuroML
 
+RUN $VENV/bin/pip install pandas==0.23.4 
+###RUN $VENV/bin/pip install matplotlib==2.2.4
 
 # Install OMV
 
 RUN git clone https://github.com/OpenSourceBrain/osb-model-validation.git
-RUN cd osb-model-validation && python setup.py install && cd -
-RUN sed -i -e s/'\/usr\/bin\/python'/'\/home\/docker\/env\/neurosci\/bin\/python'/g /usr/local/bin/omv
+RUN cd osb-model-validation && $VENV/bin/python setup.py install && cd -
+RUN sed -i -e s/'\/usr\/bin\/python'/'\/home\/docker\/env\/neurosci\/bin\/python'/g $VENV/bin/omv
 
 
 # Install jNeuroML, PyLEMS & NeuroML2
 
-RUN omv install jNeuroML
+RUN $VENV/bin/omv install jNeuroML
 ENV JNML_HOME=$HOME/jnml/jNeuroMLJar
 
-RUN omv install jLEMS
+RUN $VENV/bin/omv install jLEMS
 ENV LEMS_HOME=$HOME/jLEMS
 
-RUN omv install PyLEMS_NeuroML2
+RUN $VENV/bin/omv install PyLEMS_NeuroML2
 
 ENV PATH=$PATH:$JNML_HOME:$LEMS_HOME
 
@@ -59,19 +61,18 @@ ENV NEST_INSTALL_DIR=$HOME/env/neurosci
 
 # Install NetPyNE
 
-RUN $HOME/env/neurosci/bin/pip install pandas==0.23.4 matplotlib==2.2.4
-RUN git clone https://github.com/Neurosim-lab/netpyne.git  && \
-    cd netpyne && \
-    git checkout neuroml_updates && \
-    $HOME/env/neurosci/bin/python setup.py install && \
-    cd -
+##RUN git clone https://github.com/Neurosim-lab/netpyne.git  && \
+##    cd netpyne && \
+##    git checkout neuroml_updates && \
+##    $HOME/env/neurosci/bin/python setup.py install && \
+##    cd -
 
 
 # Install GENESIS
 
-RUN apt-get install -y bison flex unzip
-RUN omv install genesis
-ENV PATH=$PATH:$HOME/genesis/genesis2.4gamma-master/src
+###RUN apt-get install -y bison flex unzip
+###RUN $VENV/bin/omv install genesis
+###ENV PATH=$PATH:$HOME/genesis/genesis2.4gamma-master/src
 
 
 # Install OSB_API
@@ -88,36 +89,36 @@ RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 
 # Install Moose
 
-RUN omv install Moose
+###RUN omv install Moose
 
 
 # Update PyNN
 
-USER docker
-RUN $HOME/env/neurosci/bin/pip uninstall pynn -y
+###USER docker
+###RUN $VENV/bin/pip uninstall pynn -y
 
 USER root
 RUN git clone https://github.com/NeuralEnsemble/PyNN.git  && \
     cd  PyNN && \
     git checkout neuroml && \  
-    $HOME/env/neurosci/bin/python  setup.py install && \
+    $VENV/bin/python  setup.py install && \
     cd -   # neuroml branch has the latest NML2 import/export code!
 RUN which python
 
 # Update Brian
 
-RUN git clone https://github.com/brian-team/brian.git
-RUN cd brian && $HOME/env/neurosci/bin/python setup.py install && cd -
+###RUN git clone https://github.com/brian-team/brian.git
+###RUN cd brian && $HOME/env/neurosci/bin/python setup.py install && cd -
 
 
 # Install Brian2
 
-RUN $HOME/env/neurosci/bin/pip install Brian2
+##RUN $HOME/env/neurosci/bin/pip install Brian2
 
 
 # Get some latest Python packages
 
-RUN $HOME/env/neurosci/bin/pip install lazyarray --upgrade
+##RUN $HOME/env/neurosci/bin/pip install lazyarray --upgrade
 
 
 # Some aliases

--- a/osb/generate.sh
+++ b/osb/generate.sh
@@ -1,0 +1,1 @@
+docker build -t osb_newpy3 .

--- a/osb/generate.sh
+++ b/osb/generate.sh
@@ -1,1 +1,1 @@
-docker build -t osb_newpy3 .
+docker build -t neuralensemble/osb .

--- a/osb/regenerate.sh
+++ b/osb/regenerate.sh
@@ -1,0 +1,1 @@
+docker build -t osb_newpy3 --no-cache .

--- a/osb/regenerate.sh
+++ b/osb/regenerate.sh
@@ -1,1 +1,1 @@
-docker build -t osb_newpy3 --no-cache .
+docker build -t neuralensemble/osb --no-cache .

--- a/osb/runLocal.sh
+++ b/osb/runLocal.sh
@@ -1,0 +1,1 @@
+docker run -i -t osb_newpy3 /bin/bash

--- a/osb/runLocal.sh
+++ b/osb/runLocal.sh
@@ -1,1 +1,1 @@
-docker run -i -t osb_newpy3 /bin/bash
+docker run -i -t neuralensemble/osb /bin/bash

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -66,7 +66,7 @@ RUN $VENV/bin/pip install brian2==$BRIAN_VER
 #### Install PyNN
 
 ENV PYNN_VER=0.9.4
-RUN $VENV/bin/pip install neo==0.6.1 lazyarray==0.3.2 PyNN==$PYNN_VER
+RUN $VENV/bin/pip install lazyarray==0.3.2 PyNN==$PYNN_VER
 
 
 #### Set paths and activate Python environment

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -2,7 +2,7 @@
 # A Docker image for running neuronal network simulations
 #
 
-FROM neuralensemble/base
+FROM neuralensemble/base_newpy3
 MAINTAINER andrew.davison@unic.cnrs-gif.fr
 
 RUN ln -s /usr/bin/2to3-3.5 $VENV/bin/2to3
@@ -57,7 +57,9 @@ RUN mkdir $NRN; \
 RUN $VENV/bin/pip install nrnutils==0.2.0
 
 
-#### Install Brian2  # Note Brian 1.4.1 not Python 3 compatible
+#### Install Brian2  
+# Note 1: Brian 1.4.1 not Python 3 compatible
+# Note 2: For latest status on Brain 2 support in PyNN see: https://github.com/NeuralEnsemble/PyNN/pull/654
 
 ENV BRIAN_VER=2.1.3.1
 RUN $VENV/bin/pip install brian2==$BRIAN_VER

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -5,15 +5,17 @@
 FROM neuralensemble/base
 MAINTAINER andrew.davison@unic.cnrs-gif.fr
 
-ENV NEST_VER=2.14.0 NRN_VER=7.4
-ENV NEST=nest-$NEST_VER NRN=nrn-$NRN_VER
-ENV PATH=$PATH:$VENV/bin
-RUN ln -s /usr/bin/2to3-3.4 $VENV/bin/2to3
+RUN ln -s /usr/bin/2to3-3.5 $VENV/bin/2to3
+
+
+#### Install NEST
+
+ENV NEST_VER=2.16.0 
+ENV NEST=nest-simulator-$NEST_VER
 
 WORKDIR $HOME/packages
-RUN wget https://github.com/nest/nest-simulator/releases/download/v$NEST_VER/nest-$NEST_VER.tar.gz -O $HOME/packages/$NEST.tar.gz;
-RUN wget http://www.neuron.yale.edu/ftp/neuron/versions/v$NRN_VER/$NRN.tar.gz
-RUN tar xzf $NEST.tar.gz; tar xzf $NRN.tar.gz; rm $NEST.tar.gz $NRN.tar.gz
+RUN wget https://github.com/nest/nest-simulator/archive/v$NEST_VER.tar.gz -O $HOME/packages/$NEST.tar.gz;
+RUN tar xzf $NEST.tar.gz; rm $NEST.tar.gz
 RUN git clone --depth 1 https://github.com/INCF/libneurosim.git
 RUN cd libneurosim; ./autogen.sh
 
@@ -25,15 +27,26 @@ RUN mkdir libneurosim; \
     make; make install; ls $VENV/lib $VENV/include
 RUN mkdir $NEST; \
     cd $NEST; \
-    ln -s /usr/lib/python3.4/config-3.4m-x86_64-linux-gnu/libpython3.4.so $VENV/lib/; \
+    ln -s /usr/lib/python3.5/config-3.5m-x86_64-linux-gnu/libpython3.5.so $VENV/lib/; \
     cmake -DCMAKE_INSTALL_PREFIX=$VENV \
           -Dwith-mpi=ON  \
           ###-Dwith-music=ON \
           -Dwith-libneurosim=ON \
-          -DPYTHON_LIBRARY=$VENV/lib/libpython3.4.so \
-          -DPYTHON_INCLUDE_DIR=/usr/include/python3.4 \
+          -DPYTHON_LIBRARY=$VENV/lib/libpython3.5.so \
+          -DPYTHON_INCLUDE_DIR=/usr/include/python3.5 \
           $HOME/packages/$NEST; \
     make; make install
+
+
+#### Install NEURON
+
+ENV NRN_VER=7.6
+ENV NRN=nrn-$NRN_VER
+
+WORKDIR $HOME/packages
+RUN wget http://www.neuron.yale.edu/ftp/neuron/versions/v$NRN_VER/$NRN.tar.gz
+RUN tar xzf $NRN.tar.gz; rm $NRN.tar.gz
+
 RUN mkdir $NRN; \
     cd $NRN; \
     $HOME/packages/$NRN/configure --with-paranrn --with-nrnpython=$VENV/bin/python --disable-rx3d --without-iv --prefix=$VENV; \
@@ -41,8 +54,24 @@ RUN mkdir $NRN; \
     cd src/nrnpython; $VENV/bin/python setup.py install; \
     cd $VENV/bin; ln -s ../x86_64/bin/nrnivmodl
 
-RUN $VENV/bin/pip3 install lazyarray nrnutils PyNN
-RUN $VENV/bin/pip3 install brian2
+RUN $VENV/bin/pip install nrnutils==0.2.0
+
+
+#### Install Brian2  # Note Brian 1.4.1 not Python 3 compatible
+
+ENV BRIAN_VER=2.1.3.1
+RUN $VENV/bin/pip install brian2==$BRIAN_VER
+
+
+#### Install PyNN
+
+ENV PYNN_VER=0.9.4
+RUN $VENV/bin/pip install neo==0.6.1 lazyarray==0.3.2 PyNN==$PYNN_VER
+
+
+#### Set paths and activate Python environment
+
+RUN PATH=$PATH:$VENV/bin 
 
 WORKDIR /home/docker/
 RUN echo "source $VENV/bin/activate" >> .bashrc

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -61,7 +61,7 @@ RUN $VENV/bin/pip install nrnutils==0.2.0
 # Note 1: Brian 1.4.1 not Python 3 compatible
 # Note 2: For latest status on Brain 2 support in PyNN see: https://github.com/NeuralEnsemble/PyNN/pull/654
 
-ENV BRIAN_VER=2.1.3.1
+ENV BRIAN_VER=2.3
 RUN $VENV/bin/pip install brian2==$BRIAN_VER
 
 

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -8,9 +8,17 @@ MAINTAINER andrew.davison@unic.cnrs-gif.fr
 RUN ln -s /usr/bin/2to3-3.5 $VENV/bin/2to3
 
 
-#### Install NEST
+#### Set versions
 
 ENV NEST_VER=2.16.0 
+ENV NRN_VER=7.6
+# Note: see below re Brian2 support...
+ENV BRIAN2_VER=2.3   
+ENV PYNN_VER=0.9.4
+
+
+#### Install NEST
+
 ENV NEST=nest-simulator-$NEST_VER
 
 WORKDIR $HOME/packages
@@ -40,7 +48,6 @@ RUN mkdir $NEST; \
 
 #### Install NEURON
 
-ENV NRN_VER=7.6
 ENV NRN=nrn-$NRN_VER
 
 WORKDIR $HOME/packages
@@ -58,16 +65,15 @@ RUN $VENV/bin/pip install nrnutils==0.2.0
 
 
 #### Install Brian2  
+
 # Note 1: Brian 1.4.1 not Python 3 compatible
 # Note 2: For latest status on Brain 2 support in PyNN see: https://github.com/NeuralEnsemble/PyNN/pull/654
 
-ENV BRIAN_VER=2.3
-RUN $VENV/bin/pip install brian2==$BRIAN_VER
+RUN $VENV/bin/pip install brian2==$BRIAN2_VER
 
 
 #### Install PyNN
 
-ENV PYNN_VER=0.9.4
 RUN $VENV/bin/pip install lazyarray==0.3.2 PyNN==$PYNN_VER
 
 

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -2,7 +2,7 @@
 # A Docker image for running neuronal network simulations
 #
 
-FROM neuralensemble/base_newpy3
+FROM neuralensemble/base
 MAINTAINER andrew.davison@unic.cnrs-gif.fr
 
 RUN ln -s /usr/bin/2to3-3.5 $VENV/bin/2to3

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -67,7 +67,7 @@ RUN $VENV/bin/pip install nrnutils==0.2.0
 #### Install Brian2  
 
 # Note 1: Brian 1.4.1 not Python 3 compatible
-# Note 2: For latest status on Brain 2 support in PyNN see: https://github.com/NeuralEnsemble/PyNN/pull/654
+# Note 2: For latest status on Brian 2 support in PyNN see: https://github.com/NeuralEnsemble/PyNN/pull/654
 
 RUN $VENV/bin/pip install brian2==$BRIAN2_VER
 

--- a/simulation/README.md
+++ b/simulation/README.md
@@ -2,8 +2,8 @@
 
 ## What it gives you
 
-* shell environment with NEST 2.14, NEURON 7.5, and PyNN 0.9 installed.
-* The Python 2.7 version provides Brian 1.4, the Python 3.4 version provides Brian 2.
+* shell environment with NEST, NEURON, Brian and PyNN installed (for specific versions see [Dockerfile](Dockerfile)).
+* The Python 2.7 version provides Brian 1.4, the Python 3.5 version provides Brian 2.
 * IPython, scipy, matplotlib and OpenMPI are also installed.
 * use directly or as a base for your own project-specific Docker images.
 
@@ -16,7 +16,7 @@ in a Python virtual environment named "neurosci"
 docker run -i -t neuralensemble/simulation /bin/bash
 ```
 
-after which you can run simulations with Python and MPI. This will use **Python 3.4** as the Python version; if you'd prefer **Python 2.7** use:
+after which you can run simulations with Python and MPI. This will use **Python 3.5** as the Python version; if you'd prefer **Python 2.7** use:
 
 ```
 docker run -i -t neuralensemble/simulation:py2 /bin/bash

--- a/simulation/regenerate.sh
+++ b/simulation/regenerate.sh
@@ -1,1 +1,1 @@
-docker build -t neuralensemble/simulation --no-cache .
+docker build -t neuralensemble/simulation_newpy3 --no-cache .

--- a/simulation/regenerate.sh
+++ b/simulation/regenerate.sh
@@ -1,0 +1,1 @@
+docker build -t neuralensemble/simulation --no-cache .

--- a/simulation/regenerate.sh
+++ b/simulation/regenerate.sh
@@ -1,1 +1,1 @@
-docker build -t neuralensemble/simulation_newpy3 --no-cache .
+docker build -t neuralensemble/simulation --no-cache .

--- a/simulation/runLocal.sh
+++ b/simulation/runLocal.sh
@@ -1,1 +1,1 @@
-docker run -i -t neuralensemble/simulation_newpy3 /bin/bash
+docker run -i -t neuralensemble/simulation /bin/bash

--- a/simulation/runLocal.sh
+++ b/simulation/runLocal.sh
@@ -1,0 +1,1 @@
+docker run -i -t neuralensemble/simulation_newpy3 /bin/bash

--- a/simulationx/Dockerfile
+++ b/simulationx/Dockerfile
@@ -5,7 +5,7 @@
 # for SSH access and Xwindows.
 #
 
-FROM neuralensemble/simulation
+FROM neuralensemble/simulation_newpy3
 MAINTAINER andrew.davison@unic.cnrs-gif.fr
 
 USER root

--- a/simulationx/Dockerfile
+++ b/simulationx/Dockerfile
@@ -5,7 +5,7 @@
 # for SSH access and Xwindows.
 #
 
-FROM neuralensemble/simulation_newpy3
+FROM neuralensemble/simulation
 MAINTAINER andrew.davison@unic.cnrs-gif.fr
 
 USER root

--- a/simulationx/README.md
+++ b/simulationx/README.md
@@ -3,8 +3,8 @@
 
 ## What it gives you
 
-* shell environment with NEST 2.14, NEURON 7.5, and PyNN 0.9 installed.
-* The Python 2.7 version provides Brian 1.4, the Python 3.4 version provides Brian 2.
+* shell environment with NEST, NEURON, Brian and PyNN installed (for specific versions see [Dockerfile](../simulation/Dockerfile)).
+* The Python 2.7 version provides Brian 1.4, the Python 3.5 version provides Brian 2.
 * IPython, scipy, matplotlib and OpenMPI are also installed.
 * ssh access, so you can access the container with multiple terminals.
 * X-windows support, so you can display windows running in the container on your host display.
@@ -27,7 +27,7 @@ key pair).
 
 ## Python version
 
-The Dockerfiles in the [master branch](https://github.com/NeuralEnsemble/neuralensemble-docker) use **Python 3.4** as the Python version; if you'd prefer **Python 2.7** (Dockerfiles in [python2 branch](https://github.com/NeuralEnsemble/neuralensemble-docker/tree/python2)) replace `neuralensemble/simulationx` with `neuralensemble/simulationx:py2`, e.g.
+The Dockerfiles in the [master branch](https://github.com/NeuralEnsemble/neuralensemble-docker) use **Python 3.5** as the Python version; if you'd prefer **Python 2.7** (Dockerfiles in [python2 branch](https://github.com/NeuralEnsemble/neuralensemble-docker/tree/python2)) replace `neuralensemble/simulationx` with `neuralensemble/simulationx:py2`, e.g.
 
 ```
 docker run -i -t neuralensemble/simulationx:py2 /bin/bash

--- a/simulationx/regenerate.sh
+++ b/simulationx/regenerate.sh
@@ -1,1 +1,1 @@
-docker build -t neuralensemble/simulationx --no-cache .
+docker build -t neuralensemble/simulationx_newpy3 --no-cache .

--- a/simulationx/regenerate.sh
+++ b/simulationx/regenerate.sh
@@ -1,0 +1,1 @@
+docker build -t neuralensemble/simulationx --no-cache .

--- a/simulationx/regenerate.sh
+++ b/simulationx/regenerate.sh
@@ -1,1 +1,1 @@
-docker build -t neuralensemble/simulationx_newpy3 --no-cache .
+docker build -t neuralensemble/simulationx --no-cache .


### PR DESCRIPTION
Works with py3 and Pynn v0.9.4, Nrn v7.6, Nest v2.16

Note: also contains some helper scripts for (re)generating, as well as osb/Dockerfile, which extends these to install a number of other libraries/utilities/simulators for testing models on OSB 