### PR TITLE
Updated to use NEST 3.3, NEURON 8.1 & PyNN v0.10.1

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     
     - name: Build the base Docker image
       run: |
@@ -34,3 +34,11 @@ jobs:
       run: |
         cd osb       
         ./generate.sh
+
+    - name: Print info on installed packages
+      run: |
+        docker run -t  neuralensemble/osb   /bin/bash -c "omv list -V" 
+
+    - name: Print info on docker images
+      run: |
+        docker images

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /base/generate.sh
 /simulationx/runLocal.sh
 /simulationx/regenerateAll.sh
+/base/runLocal.sh

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -2,7 +2,7 @@
 # A base Docker image for Python-based computational neuroscience and neurophysiology
 #
 
-FROM neurodebian:bionic
+FROM neurodebian:focal
 MAINTAINER andrew.davison@unic.cnrs-gif.fr
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -23,7 +23,7 @@ RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 #### Set versions
 
 # This will set the versions of simulators installed with 'omv install ...'
-ENV OMV_VER=v0.2.12    
+ENV OMV_VER=v0.2.13
 
 ENV PYNEUROML_VER=1.1.1
 ENV NETPYNE_VER=1.0.5
@@ -37,7 +37,7 @@ RUN $VENV/bin/pip install pyNeuroML==$PYNEUROML_VER # will set versions of libNe
 
 # Install OMV
 
-RUN $VENV/bin/pip install git+https://github.com/OpenSourceBrain/osb-model-validation@v0.2.11
+RUN $VENV/bin/pip install git+https://github.com/OpenSourceBrain/osb-model-validation@${OMV_VER}
 RUN sed -i -e s/'\/usr\/bin\/python'/'\/home\/docker\/env\/neurosci\/bin\/python'/g $VENV/bin/omv
 
 

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -61,7 +61,7 @@ ENV NEST_INSTALL_DIR=$HOME/env/neurosci
 # Install NetPyNE
 
 RUN apt-get remove -y python3-cycler python3-matplotlib python3-dateutil
-RUN $VENV/bin/pip install matplotlib==2.2.4 pandas==0.23.4 python-dateutil==2.5.0
+#RUN $VENV/bin/pip install pandas==0.23.4 python-dateutil==2.5.0
 RUN $VENV/bin/pip install netpyne==1.0.0.2
 
 
@@ -89,9 +89,9 @@ RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 
 # Compile Moose with /usr/bin/python3, but install with venv version...
 # Caused by (not insurmountable) issue finding python headers in venv
-RUN git clone https://github.com/pgleeson/moose-core.git && cd moose-core && \
-    mkdir build_ && cd build_ && cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 .. && \
-    make -j4 && make install && cd python && $VENV/bin/python setup.py install
+##RUN git clone https://github.com/pgleeson/moose-core.git && cd moose-core && \
+##    mkdir build_ && cd build_ && cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 .. && \
+##    make -j4 && make install && cd python && $VENV/bin/python setup.py install
 
 
 # Update PyNN

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -28,8 +28,7 @@ RUN $VENV/bin/pip install pyNeuroML==0.7.5 # will set versions of libNeuroML, py
 
 # Install OMV
 
-RUN git clone https://github.com/OpenSourceBrain/osb-model-validation.git
-RUN cd osb-model-validation && $VENV/bin/python setup.py install && cd -
+RUN $VENV/bin/pip install git+https://github.com/OpenSourceBrain/osb-model-validation@test_pynn0101 
 RUN sed -i -e s/'\/usr\/bin\/python'/'\/home\/docker\/env\/neurosci\/bin\/python'/g $VENV/bin/omv
 
 
@@ -126,6 +125,7 @@ RUN which python
 
 ##RUN $HOME/env/neurosci/bin/pip install lazyarray --upgrade
 
+RUN $VENV/bin/pip install 'numpy<=1.23.0' # see https://github.com/OpenSourceBrain/osb-model-validation/issues/91
 
 # Some aliases
 

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -80,7 +80,7 @@ RUN cd OSB_API/python && python setup.py install && cd -
 
 # Install neuroConstruct
 
-RUN git clone git://github.com/NeuralEnsemble/neuroConstruct.git
+RUN git clone https://github.com/NeuralEnsemble/neuroConstruct.git
 RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 
 
@@ -119,6 +119,12 @@ RUN which python
 # Get some latest Python packages
 
 ##RUN $HOME/env/neurosci/bin/pip install lazyarray --upgrade
+
+# Install Eden
+USER docker
+ENV EDEN_VER=0.2.1
+RUN $VENV/bin/pip install eden-simulator==$EDEN_VER
+USER root
 
 
 # Some aliases

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -23,7 +23,7 @@ RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 
 # Install NeuroML Python libraries
 
-RUN $VENV/bin/pip install pyNeuroML==0.7.5 # will set versions of libNeuroML, pylems, NeuroMLlite...
+RUN $VENV/bin/pip install pyNeuroML==1.0.8 # will set versions of libNeuroML, pylems, NeuroMLlite...
 
 
 # Install OMV

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -23,7 +23,7 @@ RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 
 # Install NeuroML Python libraries
 
-RUN $VENV/bin/pip install pyNeuroML==1.0.8 # will set versions of libNeuroML, pylems, NeuroMLlite...
+RUN $VENV/bin/pip install pyNeuroML==1.0.10 # will set versions of libNeuroML, pylems, NeuroMLlite...
 
 
 # Install OMV

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -20,21 +20,30 @@ RUN apt-get install -y python3-setuptools unzip
 
 RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 
+#### Set versions
+
+# This will set the versions of simulators installed with 'omv install ...'
+ENV OMV_VER=v0.2.11     
+
+ENV PYNEUROML_VER=1.1.0
+ENV NETPYNE_VER=1.0.5
+ENV EDEN_VER=0.2.2
+
 
 # Install NeuroML Python libraries
 
-RUN $VENV/bin/pip install pyNeuroML==1.0.10 # will set versions of libNeuroML, pylems, NeuroMLlite...
+RUN $VENV/bin/pip install pyNeuroML==$PYNEUROML_VER # will set versions of libNeuroML, pylems, NeuroMLlite...
 
 
 # Install OMV
 
-RUN $VENV/bin/pip install git+https://github.com/OpenSourceBrain/osb-model-validation
+RUN $VENV/bin/pip install git+https://github.com/OpenSourceBrain/osb-model-validation@v0.2.11
 RUN sed -i -e s/'\/usr\/bin\/python'/'\/home\/docker\/env\/neurosci\/bin\/python'/g $VENV/bin/omv
 
 
 # Install jNeuroML, PyLEMS & NeuroML2
 
-RUN $VENV/bin/omv install jNeuroML
+RUN $VENV/bin/omv install jNeuroML  
 ENV JNML_HOME=$HOME/jnml/jNeuroMLJar
 
 RUN $VENV/bin/omv install jLEMS
@@ -59,8 +68,7 @@ ENV NEST_INSTALL_DIR=$HOME/env/neurosci
 # Install NetPyNE
 
 RUN apt-get remove -y python3-cycler python3-matplotlib python3-dateutil
-#RUN $VENV/bin/pip install pandas==0.23.4 python-dateutil==2.5.0
-RUN $VENV/bin/pip install git+https://github.com/suny-downstate-medical-center/netpyne@neuroml_updates
+RUN $VENV/bin/pip install netpyne==$NETPYNE_VER
 
 
 ######### Disabled for now, issues compiling on bionic....
@@ -93,7 +101,6 @@ RUN omv install arbor
 
 # Install EDEN
 
-ENV EDEN_VER=0.2.1
 RUN $VENV/bin/pip install eden-simulator==$EDEN_VER
 
 

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -85,15 +85,7 @@ RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 
 # Install Moose
 
-# Compile Moose with /usr/bin/python3, but install with venv version...
-# Caused by (not insurmountable) issue finding python headers in venv
-
-##RUN git clone https://github.com/pgleeson/moose-core.git && cd moose-core && \
-##    mkdir build_ && cd build_ && cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 .. && \
-##    make -j4 && make install && cd python && $VENV/bin/python setup.py install
-
-RUN git clone https://github.com/OpenSourceBrain/moose-core.git && cd moose-core && \
-    git checkout nml2_updates_2 && $VENV/bin/python setup.py install
+RUN omv install moose
 
 
 

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -28,7 +28,7 @@ RUN $VENV/bin/pip install pyNeuroML==0.7.5 # will set versions of libNeuroML, py
 
 # Install OMV
 
-RUN $VENV/bin/pip install git+https://github.com/OpenSourceBrain/osb-model-validation@test_pynn0101 
+RUN $VENV/bin/pip install git+https://github.com/OpenSourceBrain/osb-model-validation
 RUN sed -i -e s/'\/usr\/bin\/python'/'\/home\/docker\/env\/neurosci\/bin\/python'/g $VENV/bin/omv
 
 
@@ -60,7 +60,7 @@ ENV NEST_INSTALL_DIR=$HOME/env/neurosci
 
 RUN apt-get remove -y python3-cycler python3-matplotlib python3-dateutil
 #RUN $VENV/bin/pip install pandas==0.23.4 python-dateutil==2.5.0
-RUN $VENV/bin/pip install netpyne==1.0.2.1
+RUN $VENV/bin/pip install git+https://github.com/suny-downstate-medical-center/netpyne@neuroml_updates
 
 
 ######### Disabled for now, issues compiling on bionic....
@@ -96,34 +96,9 @@ RUN omv install arbor
 RUN omv install eden
 
 
-
-# Update PyNN
-
-###USER docker
-###RUN $VENV/bin/pip uninstall pynn -y
-
 USER root
-#RUN git clone https://github.com/NeuralEnsemble/PyNN.git  && \
-#    cd  PyNN && \
-#    git checkout 0.10.1 && \
-#    $VENV/bin/python  setup.py install && \
-#    cd -   # neuroml branch has the latest NML2 import/export code!
+
 RUN which python
-
-# Update Brian
-
-###RUN git clone https://github.com/brian-team/brian.git
-###RUN cd brian && $HOME/env/neurosci/bin/python setup.py install && cd -
-
-
-# Install Brian2
-
-##RUN $HOME/env/neurosci/bin/pip install Brian2
-
-
-# Get some latest Python packages
-
-##RUN $HOME/env/neurosci/bin/pip install lazyarray --upgrade
 
 RUN $VENV/bin/pip install 'numpy<=1.23.0' # see https://github.com/OpenSourceBrain/osb-model-validation/issues/91
 

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -87,6 +87,14 @@ RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 
 RUN omv install moose
 
+# Install Arbor
+
+RUN omv install arbor
+
+# Install EDEN
+
+RUN omv install eden
+
 
 
 # Update PyNN

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -23,7 +23,7 @@ RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 
 # Install NeuroML Python libraries
 
-RUN $VENV/bin/pip install pyNeuroML==0.5.19 # will set versions of libNeuroML, pylems, NeuroMLlite...
+RUN $VENV/bin/pip install pyNeuroML==0.7.5 # will set versions of libNeuroML, pylems, NeuroMLlite...
 
 
 # Install OMV
@@ -61,7 +61,7 @@ ENV NEST_INSTALL_DIR=$HOME/env/neurosci
 
 RUN apt-get remove -y python3-cycler python3-matplotlib python3-dateutil
 #RUN $VENV/bin/pip install pandas==0.23.4 python-dateutil==2.5.0
-RUN $VENV/bin/pip install netpyne==1.0.0.2
+RUN $VENV/bin/pip install netpyne==1.0.2.1
 
 
 ######### Disabled for now, issues compiling on bionic....
@@ -104,11 +104,11 @@ RUN git clone https://github.com/OpenSourceBrain/moose-core.git && cd moose-core
 ###RUN $VENV/bin/pip uninstall pynn -y
 
 USER root
-RUN git clone https://github.com/NeuralEnsemble/PyNN.git  && \
-    cd  PyNN && \
-    git checkout 0.10.0 && \
-    $VENV/bin/python  setup.py install && \
-    cd -   # neuroml branch has the latest NML2 import/export code!
+#RUN git clone https://github.com/NeuralEnsemble/PyNN.git  && \
+#    cd  PyNN && \
+#    git checkout 0.10.1 && \
+#    $VENV/bin/python  setup.py install && \
+#    cd -   # neuroml branch has the latest NML2 import/export code!
 RUN which python
 
 # Update Brian

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -91,7 +91,7 @@ RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 # Caused by (not insurmountable) issue finding python headers in venv
 ##RUN git clone https://github.com/pgleeson/moose-core.git && cd moose-core && \
 ##    mkdir build_ && cd build_ && cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 .. && \
-##    make -j4 && make install && cd python && $VENV/bin/python setup.py install
+##    make -j4 && make install && cd python && $VENV/bin/python setup.py install  
 
 
 # Update PyNN

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -102,7 +102,7 @@ RUN git clone https://github.com/pgleeson/moose-core.git && cd moose-core && \
 USER root
 RUN git clone https://github.com/NeuralEnsemble/PyNN.git  && \
     cd  PyNN && \
-    git checkout 0.9.6 && \
+    git checkout 0.10.0 && \
     $VENV/bin/python  setup.py install && \
     cd -   # neuroml branch has the latest NML2 import/export code!
 RUN which python

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -80,7 +80,7 @@ RUN cd OSB_API/python && python setup.py install && cd -
 
 # Install neuroConstruct
 
-RUN git clone git://github.com/NeuralEnsemble/neuroConstruct.git
+RUN git clone https://github.com/NeuralEnsemble/neuroConstruct
 RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 
 

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -81,7 +81,7 @@ RUN cd OSB_API/python && python setup.py install && cd -
 
 # Install neuroConstruct
 
-RUN git clone git://github.com/NeuralEnsemble/neuroConstruct.git
+RUN git clone https://github.com/NeuralEnsemble/neuroConstruct.git
 RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 
 
@@ -91,7 +91,7 @@ RUN cd neuroConstruct && ./updatenC.sh && ./nC.sh -make && cd -
 # Caused by (not insurmountable) issue finding python headers in venv
 ##RUN git clone https://github.com/pgleeson/moose-core.git && cd moose-core && \
 ##    mkdir build_ && cd build_ && cmake -DPYTHON_EXECUTABLE:FILEPATH=/usr/bin/python3 .. && \
-##    make -j4 && make install && cd python && $VENV/bin/python setup.py install  
+##    make -j4 && make install && cd python && $VENV/bin/python setup.py install
 
 
 # Update PyNN

--- a/osb/Dockerfile
+++ b/osb/Dockerfile
@@ -23,9 +23,9 @@ RUN /bin/bash -c "source ~/env/neurosci/bin/activate"
 #### Set versions
 
 # This will set the versions of simulators installed with 'omv install ...'
-ENV OMV_VER=v0.2.11     
+ENV OMV_VER=v0.2.12    
 
-ENV PYNEUROML_VER=1.1.0
+ENV PYNEUROML_VER=1.1.1
 ENV NETPYNE_VER=1.0.5
 ENV EDEN_VER=0.2.2
 

--- a/osb/regenerate.sh
+++ b/osb/regenerate.sh
@@ -1,1 +1,2 @@
 docker build -t neuralensemble/osb --no-cache .
+

--- a/osb_models/Dockerfile
+++ b/osb_models/Dockerfile
@@ -1,0 +1,42 @@
+#
+# A Docker image containing a number of core models from Open Source Brain
+#
+# This image extends the basic "simulationx" image by adding support
+# for libraries required for OSB models
+#
+
+# Version from Dockerhub
+#FROM opensourcebrain/simulation:osb-v0.8.4
+
+# Local build
+FROM neuralensemble/osb                                  
+
+MAINTAINER p.gleeson@gmail.com
+
+USER root
+
+RUN git clone https://github.com/OpenSourceBrain/osb-model-validation.git
+
+# Clone core set of models
+
+RUN osb-model-validation/utilities/getcoreosbprojects.sh
+
+# Pre-compile mod files for some models
+
+RUN cd coreprojects/SmithEtAl2013-L23DendriticSpikes/NEURON/test && nrnivmodl ../mod.files && cd -
+
+RUN cd coreprojects/ca1/NeuroML2 && nrnivmodl .. && cd -
+
+RUN cd coreprojects/SadehEtAl2017-InhibitionStabilizedNetworks && ./make_tests.sh && cd -
+
+RUN cd coreprojects/PotjansDiesmann2014/ && ./make_tests.sh && cd -
+
+# For Allen
+RUN $VENV/bin/pip install allensdk
+RUN cd coreprojects/AllenInstituteNeuroML/CellTypesDatabase/models/ && python download.py
+
+
+RUN echo "Built OSB models Docker image!"
+
+
+

--- a/osb_models/Dockerfile
+++ b/osb_models/Dockerfile
@@ -23,13 +23,15 @@ RUN osb-model-validation/utilities/getcoreosbprojects.sh
 
 # Pre-compile mod files for some models
 
-RUN cd coreprojects/SmithEtAl2013-L23DendriticSpikes/NEURON/test && nrnivmodl ../mod.files && cd -
+RUN cd coreprojects/SmithEtAl2013-L23DendriticSpikes/NEURON/test && nrnivmodl ../mod.files
 
-RUN cd coreprojects/ca1/NeuroML2 && nrnivmodl .. && cd -
+RUN cd coreprojects/L5bPyrCellHayEtAl2011/NEURON/test && nrnivmodl ../mod
 
-RUN cd coreprojects/SadehEtAl2017-InhibitionStabilizedNetworks && ./make_tests.sh && cd -
+RUN cd coreprojects/ca1/NeuroML2 && nrnivmodl .. 
 
-RUN cd coreprojects/PotjansDiesmann2014/ && ./make_tests.sh && cd -
+RUN cd coreprojects/SadehEtAl2017-InhibitionStabilizedNetworks && ./make_tests.sh
+
+RUN cd coreprojects/PotjansDiesmann2014/ && ./make_tests.sh
 
 # For Allen
 RUN $VENV/bin/pip install allensdk

--- a/osb_models/generate.sh
+++ b/osb_models/generate.sh
@@ -1,0 +1,1 @@
+docker build -t osb_models_new .

--- a/osb_models/regenerate.sh
+++ b/osb_models/regenerate.sh
@@ -1,0 +1,1 @@
+docker build -t osb_models_new --no-cache .

--- a/osb_models/runLocal.sh
+++ b/osb_models/runLocal.sh
@@ -1,0 +1,1 @@
+docker run -i -t osb_models_new /bin/bash

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -10,11 +10,11 @@ RUN ln -s /usr/bin/2to3-3.5 $VENV/bin/2to3
 
 #### Set versions
 
-ENV NEST_VER=3.1
-ENV NRN_VER=8.0.0
+ENV NEST_VER=3.3
+ENV NRN_VER=8.1.0
 # Note: see below re Brian2 support...
 ENV BRIAN2_VER=2.5.1
-ENV PYNN_VER=0.10.0
+ENV PYNN_VER=0.10.1
 
 
 #### Install NEST

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -68,6 +68,7 @@ ENV PATH=$PATH:$VENV/bin
 #### Install PyNN
 
 RUN $VENV/bin/pip install PyNN==$PYNN_VER
+RUN cd /home/docker/env/neurosci/lib/python3.8/site-packages/pyNN/neuron/nmodl; nrnivmodl; cd -
 
 
 #### Activate Python environment

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -14,7 +14,7 @@ ENV NEST_VER=2.20.0
 ENV NRN_VER=7.8.2
 # Note: see below re Brian2 support...
 ENV BRIAN2_VER=2.3
-ENV PYNN_VER=0.9.6
+ENV PYNN_VER=0.10.0
 
 
 #### Install NEST
@@ -35,14 +35,14 @@ RUN mkdir libneurosim; \
     make; make install; ls $VENV/lib $VENV/include
 RUN mkdir $NEST; \
     cd $NEST; \
-    ln -s /usr/lib/python3.6/config-3.6m-x86_64-linux-gnu/libpython3.6.so $VENV/lib/; \
+    ln -s /usr/lib/python3.8/config-3.8-x86_64-linux-gnu/libpython3.8.so $VENV/lib/; \
     cmake -DCMAKE_INSTALL_PREFIX=$VENV \
           -Dwith-mpi=ON  \
           ###-Dwith-music=ON \
           -Dwith-libneurosim=ON \
           -DPYTHON_EXECUTABLE:FILEPATH=$VENV/bin/python \
-          -DPYTHON_LIBRARY=$VENV/lib/libpython3.6.so \
-          -DPYTHON_INCLUDE_DIR=/usr/include/python3.6 \
+          -DPYTHON_LIBRARY=$VENV/lib/libpython3.8.so \
+          -DPYTHON_INCLUDE_DIR=/usr/include/python3.8 \
           $HOME/packages/$NEST; \
     make -j7; make install
 

--- a/simulation/Dockerfile
+++ b/simulation/Dockerfile
@@ -12,7 +12,6 @@ RUN ln -s /usr/bin/2to3-3.5 $VENV/bin/2to3
 
 ENV NEST_VER=3.3
 ENV NRN_VER=8.1.0
-# Note: see below re Brian2 support...
 ENV BRIAN2_VER=2.5.1
 ENV PYNN_VER=0.10.1
 
@@ -54,9 +53,7 @@ RUN $VENV/bin/pip install neuron==$NRN_VER
 
 #### Install Brian2
 
-# Note 1: Brian 1.4.1 not Python 3 compatible
-# Note 2: For latest status on Brian 2 support in PyNN see: https://github.com/NeuralEnsemble/PyNN/pull/654
-
+# Note: Brian 1.4.1 not Python 3 compatible
 RUN $VENV/bin/pip install brian2==$BRIAN2_VER
 
 


### PR DESCRIPTION
Also:

- Base image is neurodebian:focal (based on Ubuntu 20.04)
- Uses latest OMV to install other simulators including EDEN, Arbor, Moose
- Adds osb_models/Dockerfile, which clones a [core set of OSB projects](https://github.com/OpenSourceBrain/osb-model-validation/blob/master/utilities/getcoreosbprojects.sh), and can run OMV tests on these across 22 simulator configurations, 384 tests in total. 

Incorporates  #15